### PR TITLE
feat: add separate admin auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ RATE_LIMIT_MAX_REQUESTS=
 
 # auth config
 JWT_SECRET=
+JWT_ADMIN_SECRET=
+ADMIN_PASSWORD_HASH=
 
 # database config
 DATABASE_URL=postgres://user:password@localhost:5432/mydatabase

--- a/src/middleware/admin-auth.ts
+++ b/src/middleware/admin-auth.ts
@@ -1,0 +1,20 @@
+import type { NextFunction, Request, Response } from 'express'
+import jwt from 'jsonwebtoken'
+
+const adminAuthMiddleware = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const token = req.headers.authorization?.split(' ')[1]
+
+    if (!token) {
+      return res.status(403).json({ message: 'Authorization header not found!' })
+    }
+
+    jwt.verify(token, process.env.JWT_ADMIN_SECRET as string)
+
+    next()
+  } catch {
+    return res.status(403).json({ message: 'Not authenticated!' })
+  }
+}
+
+export { adminAuthMiddleware }

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,2 +1,3 @@
 export { rateLimiter } from '@/middleware/rate-limit.ts'
 export { authMiddleware } from '@/middleware/auth.ts'
+export { adminAuthMiddleware } from '@/middleware/admin-auth.ts'

--- a/src/routes/admin-auth.schemas.ts
+++ b/src/routes/admin-auth.schemas.ts
@@ -1,0 +1,14 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi'
+import { z } from 'zod'
+
+extendZodWithOpenApi(z)
+
+/*****************************************************************
+ * /admin-auth
+ */
+const adminAuth = z.object({
+  email: z.string().email().openapi({ example: 'example@email.com' }),
+  password: z.string().openapi({ example: '*********' })
+})
+
+export { adminAuth }

--- a/src/routes/admin-auth.ts
+++ b/src/routes/admin-auth.ts
@@ -1,0 +1,27 @@
+import bcrypt from 'bcryptjs'
+import express, { type Request, type Response } from 'express'
+import jwt from 'jsonwebtoken'
+
+import { adminAuth } from '@/routes/index.ts'
+
+const router = express.Router()
+
+router.post('/admin-auth', async (req: Request, res: Response) => {
+  try {
+    const { email, password } = adminAuth.parse(req.body)
+
+    const isPasswordCorrect = await bcrypt.compare(password, process.env.ADMIN_PASSWORD_HASH as string)
+
+    if (!isPasswordCorrect) {
+      return res.status(403).json({ message: `Incorrect credentials!` })
+    }
+
+    const accessToken = jwt.sign({ email }, process.env.JWT_ADMIN_SECRET as string, { expiresIn: '1h' })
+
+    return res.json({ message: `Successfully authenticated!`, accessToken })
+  } catch (error) {
+    return res.json({ message: 'An error occurred!', error })
+  }
+})
+
+export { router as adminAuthRouter }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,7 @@
 export { authRouter } from '@/routes/auth.ts'
 export { auth, authSwagger } from '@/routes/auth.schemas.ts'
+export { adminAuthRouter } from '@/routes/admin-auth.ts'
+export { adminAuth } from '@/routes/admin-auth.schemas.ts'
 export { healthRouter } from '@/routes/health.ts'
 export { healthSwagger } from '@/routes/health.schemas.ts'
 export { loyaltyRouter } from '@/routes/loyalty.ts'

--- a/src/routes/loyalty.ts
+++ b/src/routes/loyalty.ts
@@ -1,5 +1,6 @@
 import express, { type Request, type Response } from 'express'
 
+import { adminAuthMiddleware, authMiddleware } from '@/middleware/index.ts'
 import {
   createPartner,
   createTxnForMember,
@@ -17,7 +18,7 @@ import {
 
 const router = express.Router()
 
-router.get('/loyalty/:memberId/points/', (req: Request, res: Response) => {
+router.get('/loyalty/:memberId/points/', authMiddleware, (req: Request, res: Response) => {
   try {
     const { partnerId, memberId } = getPointsBalance.parse({
       partnerId: req.get('partnerId'),
@@ -32,7 +33,7 @@ router.get('/loyalty/:memberId/points/', (req: Request, res: Response) => {
   }
 })
 
-router.get('/loyalty/:memberId/transactions/', (req: Request, res: Response) => {
+router.get('/loyalty/:memberId/transactions/', authMiddleware, (req: Request, res: Response) => {
   try {
     const { partnerId, memberId } = getTransactionHistoryByClient.parse({
       partnerId: req.get('partnerId'),
@@ -44,7 +45,7 @@ router.get('/loyalty/:memberId/transactions/', (req: Request, res: Response) => 
   }
 })
 
-router.post('/loyalty/:memberId/transactions/', (req: Request, res: Response) => {
+router.post('/loyalty/:memberId/transactions/', authMiddleware, (req: Request, res: Response) => {
   try {
     const { partnerId, memberId, body } = createTxnForMember.parse({
       partnerId: req.get('partnerId'),
@@ -60,7 +61,7 @@ router.post('/loyalty/:memberId/transactions/', (req: Request, res: Response) =>
   }
 })
 
-router.get('/loyalty/:memberId/transactions/:txnId', (req: Request, res: Response) => {
+router.get('/loyalty/:memberId/transactions/:txnId', authMiddleware, (req: Request, res: Response) => {
   try {
     const { partnerId, memberId, txnId } = getTxnDetailsForMember.parse({
       partnerId: req.get('partnerId'),
@@ -76,7 +77,7 @@ router.get('/loyalty/:memberId/transactions/:txnId', (req: Request, res: Respons
   }
 })
 
-router.delete('/loyalty/:memberId/transactions/:txnId', (req: Request, res: Response) => {
+router.delete('/loyalty/:memberId/transactions/:txnId', authMiddleware, (req: Request, res: Response) => {
   try {
     const { partnerId, memberId, txnId } = reverseTxn.parse({
       partnerId: req.get('partnerId'),
@@ -90,7 +91,7 @@ router.delete('/loyalty/:memberId/transactions/:txnId', (req: Request, res: Resp
   }
 })
 
-router.put('/loyalty/:memberId/transactions/:txnId', (req: Request, res: Response) => {
+router.put('/loyalty/:memberId/transactions/:txnId', authMiddleware, (req: Request, res: Response) => {
   try {
     const { partnerId, memberId, txnId, body } = putTxnDetailsForMember.parse({
       partnerId: req.get('partnerId'),
@@ -107,7 +108,7 @@ router.put('/loyalty/:memberId/transactions/:txnId', (req: Request, res: Respons
   }
 })
 
-router.post('/loyalty/partners/', (req: Request, res: Response) => {
+router.post('/loyalty/partners/', adminAuthMiddleware, (req: Request, res: Response) => {
   try {
     const { partnerId, status, partnerDescription } = createPartner.parse(req.body)
 
@@ -119,7 +120,7 @@ router.post('/loyalty/partners/', (req: Request, res: Response) => {
   }
 })
 
-router.get('/loyalty/partners/:partnerId', (req: Request, res: Response) => {
+router.get('/loyalty/partners/:partnerId', adminAuthMiddleware, (req: Request, res: Response) => {
   try {
     const { partnerId } = getPartnerDetails.parse({ partnerId: req.params.partnerId })
 
@@ -129,7 +130,7 @@ router.get('/loyalty/partners/:partnerId', (req: Request, res: Response) => {
   }
 })
 
-router.put('/loyalty/partners/:partnerId', (req: Request, res: Response) => {
+router.put('/loyalty/partners/:partnerId', adminAuthMiddleware, (req: Request, res: Response) => {
   try {
     const { partnerId, status, partnerDescription } = updatePartnerDetails.parse({
       partnerId: req.params.partnerId,
@@ -145,7 +146,7 @@ router.put('/loyalty/partners/:partnerId', (req: Request, res: Response) => {
   }
 })
 
-router.delete('/loyalty/partners/:partnerId', (req: Request, res: Response) => {
+router.delete('/loyalty/partners/:partnerId', adminAuthMiddleware, (req: Request, res: Response) => {
   try {
     const { partnerId } = deletePartnerDetails.parse({ partnerId: req.params.partnerId })
     res.json({ message: `Successfully deleted partner with id: ${partnerId}` })
@@ -154,7 +155,7 @@ router.delete('/loyalty/partners/:partnerId', (req: Request, res: Response) => {
   }
 })
 
-router.get('/loyalty/partners/:partnerId/transactions', (req: Request, res: Response) => {
+router.get('/loyalty/partners/:partnerId/transactions', authMiddleware, (req: Request, res: Response) => {
   try {
     const { partnerId } = getTransactionHistoryByPartner.parse({ partnerId: req.params.partnerId })
     res.json({ message: `Successfully got transaction history for partnerId: ${partnerId}` })
@@ -163,7 +164,7 @@ router.get('/loyalty/partners/:partnerId/transactions', (req: Request, res: Resp
   }
 })
 
-router.get('/loyalty/partners/:partnerId/transactions/:txnId', (req: Request, res: Response) => {
+router.get('/loyalty/partners/:partnerId/transactions/:txnId', authMiddleware, (req: Request, res: Response) => {
   try {
     const { partnerId, txnId } = getTxnDetailForPartner.parse({
       partnerId: req.params.partnerId,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5,7 +5,7 @@ import { serve, setup } from 'swagger-ui-express'
 
 import { routePrefix } from '@/constants/route-prefix.ts'
 import { rateLimiter } from '@/middleware/rate-limit.ts'
-import { authRouter, healthRouter, loyaltyRouter } from '@/routes/index.ts'
+import { adminAuthRouter, authRouter, healthRouter, loyaltyRouter } from '@/routes/index.ts'
 import swaggerJSON from '@/swagger/oas.json'
 
 const app = express()
@@ -18,6 +18,7 @@ app.use(cors({ origin: process.env.CORS_ORIGIN, credentials: true }))
 
 app.use(`${routePrefix}`, healthRouter)
 app.use(`${routePrefix}`, authRouter)
+app.use(`${routePrefix}`, adminAuthRouter)
 app.use(`${routePrefix}`, loyaltyRouter)
 app.use(
   `/`,


### PR DESCRIPTION
We will use the admin auth while the public will authenticate through the normal auth by partner email.